### PR TITLE
use command line to control fan speed

### DIFF
--- a/emc2301.c
+++ b/emc2301.c
@@ -45,6 +45,7 @@ ssize_t emc2301_dev_write(struct file *file, const char __user *user, size_t spe
 {
 
 	u8 ret; 
+	u8 speedu8 = speed & 0xFF;
 	struct i2c_client *my_client; 
 	struct i2c_adapter *my_adap = i2c_get_adapter(10); // 10 means i2c-10 bus
 
@@ -57,7 +58,9 @@ ssize_t emc2301_dev_write(struct file *file, const char __user *user, size_t spe
 
 
 	my_client = i2c_new_dummy_device(my_adap, 0x2f); // 0x2f - slave address on i2c bus
-	ret = i2c_smbus_write_byte_data(my_client, 0x32, speed); // set fan speed
+	pr_info("i2c device created. \n");
+	ret = i2c_smbus_write_byte_data(my_client, 0x30, speedu8); // set fan speed
+	pr_info("i2c write command ret = %d\n", ret);
 
 	i2c_unregister_device(my_client);
 	pr_info("fan device closed. \n");

--- a/test.c
+++ b/test.c
@@ -3,8 +3,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdlib.h>
 
-int main(void)
+int main(int argc, char *argv[])
 {
 	int my_dev = open("/dev/emc2301_fan", O_RDWR);
 
@@ -12,12 +13,12 @@ int main(void)
 		perror("open failed");
 	}
 
-	char a;
-	int speed = 0;
+	char a[5] = "abcde";
+	int speed = atoi(argv[1]);
 
 	printf("file descriptor: %d\n", my_dev);
 
-	int err = write(my_dev, &speed, 1); /*set fan speed to 0.*/
+	int err = write(my_dev, a, speed); /*set fan speed.*/
 
 	if (err == -1) {
 		perror("write failed");


### PR DESCRIPTION
The speed parameter is passed from the system call write(), to the file_operations write(). Then the value is written into emc2301. The test program is also modified to take parameter from the command line. After compiling, use the command line to change the fan speed. Examples:
sudo ./test 0 // set fan speed to 0
sudo ./ test 255 // set fan speed to max
sudo ./test 256 // set fan speed to 0. This should be a problem of data type conversion:, size_t, int, u8, etc.